### PR TITLE
fwk-detect: Copy over JNIHelp.h.

### DIFF
--- a/fwk-detect/jni/com_qualcomm_qti_VndFwkDetect.cpp
+++ b/fwk-detect/jni/com_qualcomm_qti_VndFwkDetect.cpp
@@ -32,10 +32,13 @@
 #include "vndfwk-detect.h"
 
 #include "jni.h"
-#include "JNIHelp.h"
 #include <dlfcn.h>
 #include <string.h>
 #include <log/log.h>
+
+#ifndef NELEM
+#define NELEM(x) ((int) (sizeof(x) / sizeof((x)[0])))
+#endif
 
 #define VNDFWK_DETECT_LIB "libqti_vndfwk_detect.so"
 


### PR DESCRIPTION
Since only one macro is used from `JNIHelp.h`, just copy it here.