### PR TITLE
fwk-detect: Move vendor framework detection libraries to system_ext partition

### DIFF
--- a/fwk-detect/Android.bp
+++ b/fwk-detect/Android.bp
@@ -2,6 +2,7 @@ cc_library_shared {
     name: "libqti_vndfwk_detect",
     srcs: ["vndfwk-detect.c"],
     shared_libs: ["libcutils"],
+    system_ext_specific: true,
     vendor_available: true,
     export_include_dirs: ["."],
 
@@ -27,7 +28,7 @@ cc_library_shared {
     header_libs: [
         "jni_headers",
     ],
-
+    system_ext_specific: true,
     vendor_available: true,
     compile_multilib: "both",
 


### PR DESCRIPTION
libvndfwk_detect_jni.qti
libqti_vndfwk_detect

Change-Id: Ia30970f50557af68b25f05769b66c476f1d73d5e